### PR TITLE
[FIX] 팔로우/팔로워 내역 조회 시 DTO에서 제외된 필드로 인해 조회 시 500 오류 발생되는 문제

### DIFF
--- a/src/main/java/com/spoteditor/backend/follow/repository/FollowRepositoryCustomImpl.java
+++ b/src/main/java/com/spoteditor/backend/follow/repository/FollowRepositoryCustomImpl.java
@@ -30,7 +30,6 @@ public class FollowRepositoryCustomImpl implements FollowRepositoryCustom {
 				.select(Projections.constructor(FollowResponse.class,
 						follow.follower.id,
 						follow.follower.name,
-						follow.follower.email,
 						follow.follower.imageUrl
 				))
 				.from(follow)
@@ -61,7 +60,6 @@ public class FollowRepositoryCustomImpl implements FollowRepositoryCustom {
 				.select(Projections.constructor(FollowResponse.class,
 						follow.following.id,
 						follow.following.name,
-						follow.following.email,
 						follow.following.imageUrl
 				))
 				.from(follow)


### PR DESCRIPTION
## 이슈 번호, 혹은 추가한 기능에 대해 설명해주세요.

* #123

## 작업 상세 내용

- [x] Querydsl 조회 시 포함된 이메일 필드 제거

## 기타 내용

- closed #123
