### PR TITLE
온프레미스 개발서버 CI/CD 환경설정

### DIFF
--- a/.github/workflows/deploy-onpremises.yml
+++ b/.github/workflows/deploy-onpremises.yml
@@ -1,0 +1,54 @@
+name: Deploy to OnPremises Server
+
+on:
+  push:
+    branches:
+      - dev-onpremises
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: application.yml 생성
+        run: echo "${{ secrets.APPLICATION_YML_ONPREMISES }}" > ./src/main/resources/application.yml
+
+      - name: 실행 권한 부여하기
+        run: chmod +x ./gradlew
+
+      - name: Gradle build
+        run: ./gradlew clean build -x test
+
+      - name: Rename built JAR
+        run: mv ./build/libs/*SNAPSHOT.jar ./spoteditor.jar
+
+      - name: AWS credentials 설정
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ap-northeast-2
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ONPREMISES }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ONPREMISES }}
+
+      - name: 압축 생성
+        run: tar -czvf $GITHUB_SHA.tar.gz spoteditor.jar appspec.yml scripts Dockerfile docker-compose.yml nginx
+
+      - name: S3 업로드
+        run: aws s3 cp $GITHUB_SHA.tar.gz s3://spoteditor-develop-s3/$GITHUB_SHA.tar.gz
+
+      - name: 온프레미스 배포 트리거
+        run: |
+          aws deploy create-deployment
+            --application-name spoteditor
+            --deployment-config-name CodeDeployDefault.AllAtOnce
+            --deployment-group-name spoteditor-onpremise
+            --s3-location bucket=spoteditor-develop-s3,bundleType=tgz,key=$GITHUB_SHA.tar.gz
+            --region ap-northeast-2

--- a/appspec.yml
+++ b/appspec.yml
@@ -3,16 +3,17 @@ os: linux
 
 files:
   - source: /
-    destination: /home/ubuntu/Spoteditor-Backend
+    destination: /home/spoteditor/Spoteditor-Backend
     file_exists_behavior: OVERWRITE
 
 permissions:
   - object: /
-    owner: ubuntu
-    group: ubuntu
+    mode: 755     # 권한
+    owner: spoteditor
+    group: spoteditor
 
 hooks:
   ApplicationStart:
     - location: scripts/start.sh
       timeout: 180
-      runas: ubuntu
+      runas: spoteditor

--- a/conf/redis.conf
+++ b/conf/redis.conf
@@ -3,3 +3,5 @@ cluster-enabled yes
 cluster-config-file node.conf
 cluster-node-timeout 5000
 appendonly yes
+bind 0.0.0.0
+protected-mode no

--- a/conf/redis1.conf
+++ b/conf/redis1.conf
@@ -1,5 +1,0 @@
-port 6380
-cluster-enabled yes
-cluster-config-file node.conf
-cluster-node-timeout 5000
-appendonly yes

--- a/conf/redis2.conf
+++ b/conf/redis2.conf
@@ -1,5 +1,0 @@
-port 6381
-cluster-enabled yes
-cluster-config-file node.conf
-cluster-node-timeout 5000
-appendonly yes

--- a/conf/slave.conf
+++ b/conf/slave.conf
@@ -1,5 +1,0 @@
-port 6382
-cluster-enabled yes
-cluster-config-file node.conf
-cluster-node-timeout 5000
-appendonly yes

--- a/conf/slave1.conf
+++ b/conf/slave1.conf
@@ -1,5 +1,0 @@
-port 6383
-cluster-enabled yes
-cluster-config-file node.conf
-cluster-node-timeout 5000
-appendonly yes

--- a/conf/slave2.conf
+++ b/conf/slave2.conf
@@ -1,5 +1,0 @@
-port 6384
-cluster-enabled yes
-cluster-config-file node.conf
-cluster-node-timeout 5000
-appendonly yes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -174,3 +174,16 @@ services:
         condition: service_healthy
       slave-node-3:
         condition: service_healthy
+
+  nginx:
+    image: nginx:latest
+    container_name: nginx
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/conf:/etc/nginx/conf.d     # 예: default.conf
+    depends_on:
+      - spring-1
+      - spring-2
+    networks:
+      - redis-cluster-compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - ./conf/redis.conf:/usr/local/etc/redis/redis.conf
     command: redis-server /usr/local/etc/redis/redis.conf
     healthcheck:
-      test: ["CMD", "sh", "-c", "redis-cli -h redis-node-1 cluster info | grep -q 'cluster_state:ok'"]
+      test: ["CMD", "sh", "-c", "redis-cli -h redis-node-1 -p 6379 ping"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -41,15 +41,15 @@ services:
     hostname: redis-node-2
     container_name: redis-test2
     volumes:
-      - ./conf/redis1.conf:/usr/local/etc/redis/redis.conf
+      - ./conf/redis.conf:/usr/local/etc/redis/redis.conf
     command: redis-server /usr/local/etc/redis/redis.conf
     healthcheck:
-      test: ["CMD", "sh", "-c", "redis-cli -h redis-node-2 cluster info | grep -q 'cluster_state:ok'"]
+      test: ["CMD", "sh", "-c", "redis-cli -h redis-node-2 -p 6379 ping"]
       interval: 5s
       timeout: 5s
       retries: 5
     ports:
-      - "6380:6380"
+      - "6380:6379"
 
   redis-node-3:
     networks:
@@ -58,15 +58,15 @@ services:
     hostname: redis-node-3
     container_name: redis-test3
     volumes:
-      - ./conf/redis2.conf:/usr/local/etc/redis/redis.conf
+      - ./conf/redis.conf:/usr/local/etc/redis/redis.conf
     command: redis-server /usr/local/etc/redis/redis.conf
     healthcheck:
-      test: ["CMD", "sh", "-c", "redis-cli -h redis-node-3 cluster info | grep -q 'cluster_state:ok'"]
+      test: ["CMD", "sh", "-c", "redis-cli -h redis-node-3 -p 6379 ping"]
       interval: 5s
       timeout: 5s
       retries: 5
     ports:
-      - "6381:6381"
+      - "6381:6379"
 
   slave-node-1:
     networks:
@@ -75,15 +75,15 @@ services:
     hostname: slave-node-1
     container_name: redis-slave-test1
     volumes:
-      - ./conf/slave.conf:/usr/local/etc/redis/redis.conf
+      - ./conf/redis.conf:/usr/local/etc/redis/redis.conf
     command: redis-server /usr/local/etc/redis/redis.conf
     healthcheck:
-      test: ["CMD", "sh", "-c", "redis-cli -h slave-node-1 cluster info | grep -q 'cluster_state:ok'"]
+      test: ["CMD", "sh", "-c", "redis-cli -h slave-node-1 -p 6379 ping"]
       interval: 5s
       timeout: 5s
       retries: 5
     ports:
-      - "6382:6382"
+      - "6382:6379"
 
   slave-node-2:
     networks:
@@ -92,15 +92,15 @@ services:
     hostname: slave-node-2
     container_name: redis-slave-test2
     volumes:
-      - ./conf/slave1.conf:/usr/local/etc/redis/redis.conf
+      - ./conf/redis.conf:/usr/local/etc/redis/redis.conf
     command: redis-server /usr/local/etc/redis/redis.conf
     healthcheck:
-      test: ["CMD", "sh", "-c", "redis-cli -h slave-node-2 cluster info | grep -q 'cluster_state:ok'"]
+      test: ["CMD", "sh", "-c", "redis-cli -h slave-node-2 -p 6379 ping"]
       interval: 5s
       timeout: 5s
       retries: 5
     ports:
-      - "6383:6383"
+      - "6383:6379"
 
   slave-node-3:
     networks:
@@ -109,15 +109,15 @@ services:
     hostname: slave-node-3
     container_name: redis-slave-test3
     volumes:
-      - ./conf/slave2.conf:/usr/local/etc/redis/redis.conf
+      - ./conf/redis.conf:/usr/local/etc/redis/redis.conf
     command: redis-server /usr/local/etc/redis/redis.conf
     healthcheck:
-      test: ["CMD", "sh", "-c", "redis-cli -h slave-node-3 cluster info | grep -q 'cluster_state:ok'"]
+      test: ["CMD", "sh", "-c", "redis-cli -h slave-node-3 -p 6379 ping"]
       interval: 5s
       timeout: 5s
       retries: 5
     ports:
-      - "6384:6384"
+      - "6384:6379"
 
   redis-cluster-entry:
     networks:
@@ -126,7 +126,7 @@ services:
     restart: no
     container_name: redis-cluster-entry
     #command: redis-cli --cluster create 127.0.0.1:6379 127.0.0.1:6380 127.0.0.1:6381 127.0.0.1:6382 127.0.0.1:6383 127.0.0.1:6384 --cluster-replicas 1 --cluster-yes
-    command: sh -c "redis-cli --cluster create redis-node-1:6379 redis-node-2:6380 redis-node-3:6381 slave-node-1:6382 slave-node-2:6383 slave-node-3:6384 --cluster-replicas 1 --cluster-yes && tail -f /dev/null"
+    command: sh -c "redis-cli --cluster create redis-node-1:6379 redis-node-2:6379 redis-node-3:6379 slave-node-1:6379 slave-node-2:6379 slave-node-3:6379 --cluster-replicas 1 --cluster-yes && tail -f /dev/null"
     depends_on:
       - redis-node-1
       - redis-node-2
@@ -139,10 +139,8 @@ services:
     build: .
     networks:
       - redis-cluster-compose
-    environment:
-      - SERVER_PORT=8080
-    ports:
-      - "8080:8080"
+    expose:
+      - "8080"
     depends_on:
       redis-node-1:
         condition: service_healthy
@@ -161,10 +159,8 @@ services:
     build: .
     networks:
       - redis-cluster-compose
-    environment:
-      - SERVER_PORT=8081
-    ports:
-      - "8081:8081"
+    expose:
+      - "8080"
     depends_on:
       redis-node-1:
         condition: service_healthy

--- a/nginx/conf/default.conf
+++ b/nginx/conf/default.conf
@@ -1,0 +1,47 @@
+#요청 속도 제한 - IP기준 초당 5회
+limit_req_zone $binary_remote_addr zone=api_limit:10m rate=5r/s;
+
+upstream backend {
+    server spring-1:8080;
+    server spring-2:8080;
+}
+
+server {
+    listen 80;
+
+    # Backend 프록시
+    location /api/ {
+        proxy_pass http://backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-for $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # swagger
+    location /swagger-ui/ {
+        proxy_pass http://backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # vercel (프런트)
+    location / {
+        proxy_pass https://spoteditor-frontend.vercel.app;
+        proxy_set_header Host spoteditor-frontend.vercel.app;
+        proxy_set_header X-Real_IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_ssl_server_name on;
+    }
+
+    error_page 429 =429 /rate-limit.html;
+
+    location = /rate-limite.html {
+        root /usr/share/nginx/html;
+        internal;
+    }
+}

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,6 +1,8 @@
 echo "--------------- 서버 배포 시작 -----------------"
-cd /home/ubuntu/Spoteditor-Backend
+cd /home/spoteditor/Spoteditor-Backend
+
+echo "--------------- 기존 도커 컨테이너 다운 -----------------"
 docker compose down || true
-docker pull 891612578477.dkr.ecr.ap-northeast-2.amazonaws.com/spoteditor:latest
+echo "--------------- 도커 컴포즈 이미지 업 -----------------"
 docker compose up -d --build
 echo "--------------- 서버 배포 끝 -----------------"


### PR DESCRIPTION
## AWS
- 기존 S3 저장소 [spoteditor-develop-s3] 분리
- 기존 code deploy 배포 그룹 [SpotEditor-Dev] 분리
- 접근계정 QQQ로 변경
---
## 환경
- Redis 컨테이너 내부 포트 6379 통합
- Nginx 로드밸런싱(라운드로빈), 리버스 프록시 적용