### PR TITLE
로드밸런서 분산서버 환경에서 OAuth 인증처리 오류 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,8 +180,10 @@ services:
     container_name: nginx
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - ./nginx/conf:/etc/nginx/conf.d     # 예: default.conf
+      - /etc/letsencrypt:/etc/letsencrypt:ro
     depends_on:
       - spring-1
       - spring-2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
       - redis-cluster-compose
     image: rabbitmq:management-alpine
     container_name: rabbit-mq-container
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
     hostname: rabbitmq
     ports:
       - "5672:5672"
@@ -25,6 +28,8 @@ services:
     container_name: redis-test1
     volumes:
       - ./conf/redis.conf:/usr/local/etc/redis/redis.conf
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
     command: redis-server /usr/local/etc/redis/redis.conf
     healthcheck:
       test: ["CMD", "sh", "-c", "redis-cli -h redis-node-1 -p 6379 ping"]
@@ -42,6 +47,8 @@ services:
     container_name: redis-test2
     volumes:
       - ./conf/redis.conf:/usr/local/etc/redis/redis.conf
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
     command: redis-server /usr/local/etc/redis/redis.conf
     healthcheck:
       test: ["CMD", "sh", "-c", "redis-cli -h redis-node-2 -p 6379 ping"]
@@ -59,6 +66,8 @@ services:
     container_name: redis-test3
     volumes:
       - ./conf/redis.conf:/usr/local/etc/redis/redis.conf
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
     command: redis-server /usr/local/etc/redis/redis.conf
     healthcheck:
       test: ["CMD", "sh", "-c", "redis-cli -h redis-node-3 -p 6379 ping"]
@@ -76,6 +85,8 @@ services:
     container_name: redis-slave-test1
     volumes:
       - ./conf/redis.conf:/usr/local/etc/redis/redis.conf
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
     command: redis-server /usr/local/etc/redis/redis.conf
     healthcheck:
       test: ["CMD", "sh", "-c", "redis-cli -h slave-node-1 -p 6379 ping"]
@@ -93,6 +104,8 @@ services:
     container_name: redis-slave-test2
     volumes:
       - ./conf/redis.conf:/usr/local/etc/redis/redis.conf
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
     command: redis-server /usr/local/etc/redis/redis.conf
     healthcheck:
       test: ["CMD", "sh", "-c", "redis-cli -h slave-node-2 -p 6379 ping"]
@@ -110,6 +123,8 @@ services:
     container_name: redis-slave-test3
     volumes:
       - ./conf/redis.conf:/usr/local/etc/redis/redis.conf
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
     command: redis-server /usr/local/etc/redis/redis.conf
     healthcheck:
       test: ["CMD", "sh", "-c", "redis-cli -h slave-node-3 -p 6379 ping"]
@@ -139,6 +154,9 @@ services:
     build: .
     networks:
       - redis-cluster-compose
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
     expose:
       - "8080"
     depends_on:
@@ -159,6 +177,9 @@ services:
     build: .
     networks:
       - redis-cluster-compose
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
     expose:
       - "8080"
     depends_on:
@@ -184,6 +205,8 @@ services:
     volumes:
       - ./nginx/conf:/etc/nginx/conf.d     # 예: default.conf
       - /etc/letsencrypt:/etc/letsencrypt:ro
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
     depends_on:
       - spring-1
       - spring-2

--- a/nginx/conf/default.conf
+++ b/nginx/conf/default.conf
@@ -6,6 +6,45 @@ upstream backend {
     server spring-2:8080;
 }
 
+server{
+    listen 443 ssl;
+    server_name spoteditor.duckdns.org;
+
+    ssl_certificate /etc/letsencrypt/live/spoteditor.duckdns.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/spoteditor.duckdns.org/privkey.pem;
+
+    # Backend 프록시
+    location /api/ {
+        proxy_pass http://backend;
+        proxy_http_version 1.1;
+        limit_req zone=api_limit burst=10 nodelay;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-for $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # swagger
+        location /swagger-ui/ {
+            proxy_pass http://backend;
+            proxy_http_version 1.1;
+            limit_req zone=api_limit burst=10 nodelay;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # vercel (프런트)
+        location / {
+            proxy_pass https://spoteditor-frontend.vercel.app;
+            proxy_set_header Host spoteditor-frontend.vercel.app;
+            proxy_set_header X-Real_IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_ssl_server_name on;
+        }
+}
+
 server {
     listen 80;
 
@@ -44,4 +83,7 @@ server {
         root /usr/share/nginx/html;
         internal;
     }
+
+    # 모든 요청을 HTTPS로 리다이렉트
+    return 301 https://$host$request_uri;
 }

--- a/nginx/conf/default.conf
+++ b/nginx/conf/default.conf
@@ -13,6 +13,9 @@ server{
     ssl_certificate /etc/letsencrypt/live/spoteditor.duckdns.org/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/spoteditor.duckdns.org/privkey.pem;
 
+    #브라우저에서 https로 접근을 기억
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
     # Backend 프록시
     location /api/ {
         proxy_pass http://backend;

--- a/nginx/conf/default.conf
+++ b/nginx/conf/default.conf
@@ -1,4 +1,4 @@
-#요청 속도 제한 - IP기준 초당 5회
+# 요청 속도 제한 - IP 기준 초당 5회
 limit_req_zone $binary_remote_addr zone=api_limit:10m rate=5r/s;
 
 upstream backend {
@@ -6,88 +6,75 @@ upstream backend {
     server spring-2:8080;
 }
 
-server{
+server {
     listen 443 ssl;
     server_name spoteditor.duckdns.org;
 
     ssl_certificate /etc/letsencrypt/live/spoteditor.duckdns.org/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/spoteditor.duckdns.org/privkey.pem;
 
-    #브라우저에서 https로 접근을 기억
+    # 브라우저에서 HTTPS로 접근 기억
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
-    # Backend 프록시
     location /api/ {
         proxy_pass http://backend;
-        proxy_http_version 1.1;
         limit_req zone=api_limit burst=10 nodelay;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-for $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    # swagger
-        location /swagger-ui/ {
-            proxy_pass http://backend;
-            proxy_http_version 1.1;
-            limit_req zone=api_limit burst=10 nodelay;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-        }
-
-        # vercel (프런트)
-        location / {
-            proxy_pass https://spoteditor-frontend.vercel.app;
-            proxy_set_header Host spoteditor-frontend.vercel.app;
-            proxy_set_header X-Real_IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_ssl_server_name on;
-        }
-}
-
-server {
-    listen 80;
-
-    # Backend 프록시
-    location /api/ {
-        proxy_pass http://backend;
         proxy_http_version 1.1;
-        limit_req zone=api_limit burst=10 nodelay;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-for $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    # swagger
-    location /swagger-ui/ {
-        proxy_pass http://backend;
-        proxy_http_version 1.1;
-        limit_req zone=api_limit burst=10 nodelay;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # vercel (프런트)
+    location /login/oauth2/ {
+        proxy_pass http://backend;
+        limit_req zone=api_limit burst=10 nodelay;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /oauth2/ {
+        proxy_pass http://backend;
+        limit_req zone=api_limit burst=10 nodelay;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /swagger-ui/ {
+        proxy_pass http://backend;
+        limit_req zone=api_limit burst=10 nodelay;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location / {
         proxy_pass https://spoteditor-frontend.vercel.app;
         proxy_set_header Host spoteditor-frontend.vercel.app;
-        proxy_set_header X-Real_IP $remote_addr;
+        proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_ssl_server_name on;
     }
 
+    # 429 에러 처리
     error_page 429 =429 /rate-limit.html;
-
-    location = /rate-limite.html {
+    location = /rate-limit.html {
         root /usr/share/nginx/html;
         internal;
     }
+}
+
+server {
+    listen 80;
+    server_name spoteditor.duckdns.org;
 
     # 모든 요청을 HTTPS로 리다이렉트
     return 301 https://$host$request_uri;

--- a/nginx/conf/default.conf
+++ b/nginx/conf/default.conf
@@ -52,6 +52,7 @@ server {
     location /api/ {
         proxy_pass http://backend;
         proxy_http_version 1.1;
+        limit_req zone=api_limit burst=10 nodelay;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-for $proxy_add_x_forwarded_for;
@@ -62,6 +63,7 @@ server {
     location /swagger-ui/ {
         proxy_pass http://backend;
         proxy_http_version 1.1;
+        limit_req zone=api_limit burst=10 nodelay;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/scripts/ssl_reload.sh
+++ b/scripts/ssl_reload.sh
@@ -1,0 +1,12 @@
+NGINX_CONTAINER_NAME=nginx
+
+echo "nginx 컨테이너 정지"
+docker stop $NGINX_CONTAINER_NAME
+
+echo "인증서 갱신"
+sudo certbot renew --quiet
+
+echo "nginx 컨테이너 시작"
+docker start $NGINX_CONTAINER_NAME
+
+echo "인증서 갱신완료"

--- a/src/main/java/com/spoteditor/backend/config/oauth/handler/OauthSuccessHandler.java
+++ b/src/main/java/com/spoteditor/backend/config/oauth/handler/OauthSuccessHandler.java
@@ -1,9 +1,8 @@
 package com.spoteditor.backend.config.oauth.handler;
 
-import com.spoteditor.backend.config.util.CookieUtils;
 import com.spoteditor.backend.config.jwt.JwtConstants;
 import com.spoteditor.backend.config.jwt.JwtUtils;
-import com.spoteditor.backend.global.exception.UserException;
+import com.spoteditor.backend.config.util.CookieUtils;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -17,10 +16,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
-
-import static com.spoteditor.backend.global.response.ErrorCode.USER_ROLE_MISSING;
 
 @Component
 @RequiredArgsConstructor
@@ -51,7 +47,7 @@ public class OauthSuccessHandler implements AuthenticationSuccessHandler {
         cookieUtils.setAccessTokenCookie(response, JwtConstants.ACCESS_TOKEN, accessToken);
         cookieUtils.setRefreshTokenCookie(response, JwtConstants.REFRESH_TOKEN, refreshToken);
 
-//        redirect
+        // redirect
         response.sendRedirect(successRedirectUrl);
     }
 }

--- a/src/main/java/com/spoteditor/backend/config/oauth/service/RedisOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/spoteditor/backend/config/oauth/service/RedisOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,103 @@
+package com.spoteditor.backend.config.oauth.service;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.flywaydb.core.internal.util.StringUtils;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.web.util.WebUtils;
+
+import java.time.Duration;
+import java.util.Base64;
+
+/**
+ *      로드밸런서를 사용하면서 OAuth2.0 인증과정에서 요청과 리다이렉트를 각각 다른 서버에서 처리하는 이슈 발생
+ *      Redis에 인증 요청 정보를 저장하여 모든 분산 서버에서 상태 정보를 공유하도록 함
+ */
+public class RedisOAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository {
+
+    private static final String COOKIE_NAME = "OAUTH2_AUTH_REQUEST";        // Redis 키값을 저장할 쿠키 이름
+    private static final Duration EXPIRATION = Duration.ofMinutes(3);       // 인증 상태의 유효기간 (최대 3분)
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public RedisOAuth2AuthorizationRequestRepository(RedisTemplate<String, Object> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    /**
+     * 쿠키에 들어있는 Redis 키값을 이용해 OAuth2 인증 요청 상태를 로드
+     */
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        Cookie cookie = WebUtils.getCookie(request, COOKIE_NAME);
+        if (cookie != null && StringUtils.hasText(cookie.getValue())) {
+            String key = decodeKey(cookie.getValue());
+            return (OAuth2AuthorizationRequest) redisTemplate.opsForValue().get(key);
+        }
+        return null;
+    }
+
+    /**
+     * 인증 요청 정보를 Redis에 저장하고, Redis 키를 쿠키에 저장
+     */
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            removeAuthorizationRequest(request, response);
+            return;
+        }
+
+        String key = generateKey(authorizationRequest);
+
+        // redis에 request정보 저장
+        redisTemplate.opsForValue().set(key, authorizationRequest, EXPIRATION);
+
+        // redis키 쿠키에 저장
+        Cookie cookie = new Cookie(COOKIE_NAME, encodeKey(key));
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge((int) EXPIRATION.getSeconds());
+        response.addCookie(cookie);
+    }
+
+    /**
+     * 인증 요청 완료 후 Redis와 쿠키에서 상태 정보를 제거함
+     * fail / success 상관없이 호출됨
+     */
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request, HttpServletResponse response) {
+
+        // 저장된 키값 제거
+        OAuth2AuthorizationRequest requestObj = loadAuthorizationRequest(request);
+        if (requestObj != null) {
+            String key = generateKey(requestObj);
+            redisTemplate.delete(key);
+        }
+
+        // 쿠키 강제 만료
+        Cookie cookie = new Cookie(COOKIE_NAME, null);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+
+        return requestObj;
+    }
+
+    /**
+     * OAuth2AuthorizationRequest의 state 값을 기반으로 Redis 키 생성
+     */
+    private String generateKey(OAuth2AuthorizationRequest request) {
+        return "oauth2:auth-request:" + request.getState();
+    }
+
+    private String encodeKey(String key) {
+        return Base64.getUrlEncoder().encodeToString(key.getBytes());
+    }
+
+    private String decodeKey(String encodedKey) {
+        return new String(Base64.getUrlDecoder().decode(encodedKey));
+    }
+}

--- a/src/main/java/com/spoteditor/backend/config/redis/RedisConfiguration.java
+++ b/src/main/java/com/spoteditor/backend/config/redis/RedisConfiguration.java
@@ -6,6 +6,11 @@ import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @RequiredArgsConstructor
@@ -24,5 +29,15 @@ public class RedisConfiguration {
 				.addNodeAddress(nodes);
 
 		return Redisson.create(config);
+	}
+
+	// oauth2 인증을 위한 레디스 클러스터 저장 규격
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(redisConnectionFactory);
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setValueSerializer(new JdkSerializationRedisSerializer());
+		return template;
 	}
 }

--- a/src/main/java/com/spoteditor/backend/config/security/SecurityConfig.java
+++ b/src/main/java/com/spoteditor/backend/config/security/SecurityConfig.java
@@ -1,23 +1,25 @@
 package com.spoteditor.backend.config.security;
 
-import com.spoteditor.backend.config.util.CookieUtils;
 import com.spoteditor.backend.config.jwt.JwtFilter;
 import com.spoteditor.backend.config.jwt.JwtUtils;
 import com.spoteditor.backend.config.oauth.handler.OauthFailureHandler;
 import com.spoteditor.backend.config.oauth.handler.OauthSuccessHandler;
 import com.spoteditor.backend.config.oauth.service.CustomOauthUserService;
+import com.spoteditor.backend.config.oauth.service.RedisOAuth2AuthorizationRequestRepository;
+import com.spoteditor.backend.config.util.CookieUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfigurationSource;
-
-import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
 @EnableWebSecurity
@@ -25,6 +27,8 @@ import static org.springframework.security.config.Customizer.withDefaults;
 public class SecurityConfig {
 
     private final CustomOauthUserService customOauthUserService;
+    
+    // OAuth 처리 핸들러
     private final OauthSuccessHandler oauthSuccessHandler;
     private final OauthFailureHandler oauthFailureHandler;
 
@@ -34,7 +38,16 @@ public class SecurityConfig {
     private final CorsConfigurationSource corsConfigurationSource;
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public AuthorizationRequestRepository<OAuth2AuthorizationRequest> redisAuthorizationRequestRepository(RedisTemplate<String, Object> redisTemplate) {
+        return new RedisOAuth2AuthorizationRequestRepository(redisTemplate);
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http,
+                                           AuthorizationRequestRepository<OAuth2AuthorizationRequest> authRequestRespsitory,
+                                           OauthSuccessHandler successHandler,
+                                           OauthFailureHandler failureHandler) throws Exception {
+
         http
             .cors(cors -> cors.configurationSource(corsConfigurationSource))
             .formLogin(AbstractHttpConfigurer::disable)
@@ -44,14 +57,17 @@ public class SecurityConfig {
             )
             .addFilterBefore(new JwtFilter(jwtUtils, cookieUtils), UsernamePasswordAuthenticationFilter.class)
             .authorizeHttpRequests(authorize -> authorize
-                .requestMatchers("/**").permitAll()
-                .anyRequest().authenticated()
+                    .requestMatchers("/**").permitAll()
+                    .anyRequest().authenticated()
             )
             .oauth2Login(oauth2 -> oauth2
-                .userInfoEndpoint(userInfoEndpointConfig
-                    -> userInfoEndpointConfig.userService(customOauthUserService))
-                .successHandler(oauthSuccessHandler)
-                .failureHandler(oauthFailureHandler)
+                    // LB분산 서버 처리, oauth 요청 처리를 위한 요청 저장 repository
+                    .authorizationEndpoint(endpoint ->
+                            endpoint.authorizationRequestRepository(authRequestRespsitory))
+                    .userInfoEndpoint(userInfoEndpointConfig ->
+                            userInfoEndpointConfig.userService(customOauthUserService))
+                    .successHandler(oauthSuccessHandler)
+                    .failureHandler(oauthFailureHandler)
             );
 
         return http.build();


### PR DESCRIPTION
## 원인
### Load Balancer(라운드 로빈) 분산처리로 인해 OAuth2 인증요청시 최초 인증을 요청한 서버와 인증서버에서 redirect 되는 요청을 처리하는 서버가 상이해서 문제발생 state 코드값이 리다이렉트 처리시 존재하지 않아 브라우저 측으로 302 redirect가 아닌 200/ok status를 전송하여 브라우저에서 "/" 메인경로로 리다이렉트를 수행하지않음
- 기존 요청을 Redis cluster를 통해 공유하여 분산 처리 시에도 기존 요청에 대한 정보를 cookie와 redis를 통하여 확인하고 이어서 처리 가능하게 수정

---
## 기타 설정
- 컨테이너 timezone 설정 로컬 서버 asia/seoul 값으로 동기화
-  nginx 80포트(http) 중복 매핑값 제거

---
- [카카오 로그인](https://spoteditor.duckdns.org/oauth2/authorization/kakao) 테스트 완료 (쿠키값 Access/Refresh Token 생성확인)
![image](https://github.com/user-attachments/assets/20a8e28b-6797-4062-be94-8d585f7c307a)


- 위 카카오 로그인 후 [사용자 정보 호출](https://spoteditor.duckdns.org/api/users) 테스트 완료
![image](https://github.com/user-attachments/assets/e874bf44-d006-49fe-aa23-cbc5a62986c6)