### PR TITLE
[hotfix🚑] 커밋꼬임 Reset을 통한 정리

### DIFF
--- a/.github/workflows/deploy-onpremises.yml
+++ b/.github/workflows/deploy-onpremises.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-          ssh-key: ${{ secretes.DEPLOY_PRIVATE_SUBMODULES_KEY }}
+          ssh-key: ${{ secrets.DEPLOY_PRIVATE_SUBMODULES_KEY }}
 
       - name: Setup JDK 17
         uses: actions/setup-java@v4


### PR DESCRIPTION
간단한 작업들을 별도 브랜치 분할 없이 dev-onpremises 브랜치에서 작업하여 올려놨더니 PR 머지 과정에서 커밋 이력이 꼬여 git reset으로 정리하였습니다.
해당 reset 내용은 별도의 PR로 다시 제출할 예정입니다.